### PR TITLE
Updated unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target
 .classpath
 .project
 .settings
+tmp
+tmp_VocabularySearchRelatedCommandsTest

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,3 @@ target
 .classpath
 .project
 .settings
-tmp
-tmp_VocabularySearchRelatedCommandsTest

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>nl.dtls</groupId>

--- a/src/test/java/com/google/refine/test/org/deri/reconcile/GRefineServiceManagerTest.java
+++ b/src/test/java/com/google/refine/test/org/deri/reconcile/GRefineServiceManagerTest.java
@@ -31,7 +31,7 @@ import com.hp.hpl.jena.rdf.model.ModelFactory;
 public class GRefineServiceManagerTest {
 
 	String url = "http://example.org/endpoint";
-	File dir = new File("tmp");
+	File dir = new File("target/tmp");
 	
 	@BeforeClass
 	public void setUp() throws IOException{

--- a/src/test/java/com/google/refine/test/org/deri/reconcile/GRefineServiceManagerTest.java
+++ b/src/test/java/com/google/refine/test/org/deri/reconcile/GRefineServiceManagerTest.java
@@ -9,11 +9,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
 
-import org.json.JSONException;
-import org.json.JSONWriter;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
 import org.deri.grefine.reconcile.GRefineServiceManager;
 import org.deri.grefine.reconcile.ServiceRegistry;
 import org.deri.grefine.reconcile.model.ReconciliationRequest;
@@ -22,8 +17,14 @@ import org.deri.grefine.reconcile.rdf.RdfReconciliationService;
 import org.deri.grefine.reconcile.rdf.endpoints.QueryEndpointImpl;
 import org.deri.grefine.reconcile.rdf.executors.DumpQueryExecutor;
 import org.deri.grefine.reconcile.rdf.executors.RemoteQueryExecutor;
+import org.deri.grefine.reconcile.rdf.factories.JenaTextSparqlQueryFactory;
 // import org.deri.grefine.reconcile.rdf.factories.LarqSparqlQueryFactory;
 import org.deri.grefine.reconcile.util.GRefineJsonUtilitiesImpl;
+import org.json.JSONException;
+import org.json.JSONWriter;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 
@@ -66,7 +67,7 @@ public class GRefineServiceManagerTest {
 		ServiceRegistry registry = new ServiceRegistry(new GRefineJsonUtilitiesImpl(),null);
 		GRefineServiceManager manager = new GRefineServiceManager(registry, dir);
 		
-		ReconciliationService service = new RdfReconciliationService(id, id, new QueryEndpointImpl(new LarqSparqlQueryFactory(), new RemoteQueryExecutor(url, null)), 0);
+		ReconciliationService service = new RdfReconciliationService(id, id, new QueryEndpointImpl(new JenaTextSparqlQueryFactory(), new RemoteQueryExecutor(url, null)), 0);
 		manager.addService(service);
 		
 		assertTrue(registry.hasService(id));
@@ -94,7 +95,7 @@ public class GRefineServiceManagerTest {
 		GRefineServiceManager manager = new GRefineServiceManager(registry, dir);
 		
 		Model m = ModelFactory.createDefaultModel();
-		ReconciliationService service = new RdfReconciliationService(id,id, new QueryEndpointImpl(new LarqSparqlQueryFactory(), 
+		ReconciliationService service = new RdfReconciliationService(id,id, new QueryEndpointImpl(new JenaTextSparqlQueryFactory(), 
 				new DumpQueryExecutor(m)), 0);
 		manager.addAndSaveService(service);
 		

--- a/src/test/java/com/google/refine/test/org/deri/reconcile/endpoints/LarqSparqlEndpointTest.java
+++ b/src/test/java/com/google/refine/test/org/deri/reconcile/endpoints/LarqSparqlEndpointTest.java
@@ -12,10 +12,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 import org.deri.grefine.reconcile.model.ReconciliationCandidate;
 import org.deri.grefine.reconcile.model.ReconciliationRequest;
 import org.deri.grefine.reconcile.model.SearchResultItem;
@@ -23,7 +19,11 @@ import org.deri.grefine.reconcile.rdf.endpoints.QueryEndpoint;
 import org.deri.grefine.reconcile.rdf.endpoints.QueryEndpointImpl;
 import org.deri.grefine.reconcile.rdf.executors.DumpQueryExecutor;
 import org.deri.grefine.reconcile.rdf.executors.QueryExecutor;
-import org.deri.grefine.reconcile.rdf.factories.LarqSparqlQueryFactory;
+import org.deri.grefine.reconcile.rdf.factories.JenaTextSparqlQueryFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.ModelFactory;
 
@@ -36,7 +36,7 @@ import com.hp.hpl.jena.rdf.model.ModelFactory;
 public class LarqSparqlEndpointTest {
 
 	QueryExecutor executor;
-	LarqSparqlQueryFactory factory;
+	JenaTextSparqlQueryFactory factory;
 	QueryEndpoint endpoint;
 	
 	//query
@@ -53,7 +53,7 @@ public class LarqSparqlEndpointTest {
 		m.read(in,null,"TTL");
 		
 		executor = new DumpQueryExecutor(m);
-		factory = new LarqSparqlQueryFactory();
+		factory = new JenaTextSparqlQueryFactory();
 		endpoint = new QueryEndpointImpl(factory, executor);
 	}
 	

--- a/src/test/java/com/google/refine/test/org/deri/reconcile/executors/JenaTextSparqlQueryExecutorTest.java
+++ b/src/test/java/com/google/refine/test/org/deri/reconcile/executors/JenaTextSparqlQueryExecutorTest.java
@@ -9,10 +9,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 import org.deri.grefine.reconcile.model.ReconciliationRequest;
 import org.deri.grefine.reconcile.model.ReconciliationRequestContext;
 import org.deri.grefine.reconcile.model.ReconciliationRequestContext.IdentifiedValueContext;
@@ -20,7 +16,11 @@ import org.deri.grefine.reconcile.model.ReconciliationRequestContext.PropertyCon
 import org.deri.grefine.reconcile.model.ReconciliationRequestContext.TextualValueContext;
 import org.deri.grefine.reconcile.rdf.executors.DumpQueryExecutor;
 import org.deri.grefine.reconcile.rdf.executors.QueryExecutor;
-import org.deri.grefine.reconcile.rdf.factories.LarqSparqlQueryFactory;
+import org.deri.grefine.reconcile.rdf.factories.JenaTextSparqlQueryFactory;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
 import com.hp.hpl.jena.query.QuerySolution;
 import com.hp.hpl.jena.query.ResultSet;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -32,10 +32,10 @@ import com.hp.hpl.jena.rdf.model.Resource;
  * this class mainly tests that queries produced by {@link org.deri.refine.reconcile.rdf.factories.LarqSparqlQueryFactory LarqSparqlQueryFactory}
  * are correct (executable)
  */
-public class LarqSparqlQueryExecutorTest {
+public class JenaTextSparqlQueryExecutorTest {
 
 	QueryExecutor executor;
-	LarqSparqlQueryFactory factory;
+	JenaTextSparqlQueryFactory factory;
 	
 	//query
 	int limit =8;
@@ -50,7 +50,7 @@ public class LarqSparqlQueryExecutorTest {
 		m.read(in,null,"TTL");
 		
 		executor = new DumpQueryExecutor(m);
-		factory = new LarqSparqlQueryFactory();
+		factory = new JenaTextSparqlQueryFactory();
 	}
 	
 	@Test

--- a/src/test/java/com/google/refine/test/org/deri/reconcile/factories/JenaTextSparqlQueryFactoryTest.java
+++ b/src/test/java/com/google/refine/test/org/deri/reconcile/factories/JenaTextSparqlQueryFactoryTest.java
@@ -2,20 +2,19 @@ package com.google.refine.test.org.deri.reconcile.factories;
 
 import static org.testng.Assert.assertEquals;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import com.google.common.collect.ImmutableList;
 import org.deri.grefine.reconcile.model.ReconciliationRequest;
 import org.deri.grefine.reconcile.model.ReconciliationRequestContext;
 import org.deri.grefine.reconcile.model.ReconciliationRequestContext.IdentifiedValueContext;
 import org.deri.grefine.reconcile.model.ReconciliationRequestContext.PropertyContext;
 import org.deri.grefine.reconcile.model.ReconciliationRequestContext.TextualValueContext;
-import org.deri.grefine.reconcile.rdf.factories.LarqSparqlQueryFactory;
+import org.deri.grefine.reconcile.rdf.factories.JenaTextSparqlQueryFactory;
 import org.deri.grefine.reconcile.rdf.factories.SparqlQueryFactory;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 
-public class LarqSparqlQueryFactoryTest {
+public class JenaTextSparqlQueryFactoryTest {
 
 	int limit = 10;
 	String query = "Fadi Maali";
@@ -23,7 +22,7 @@ public class LarqSparqlQueryFactoryTest {
 	
 	@BeforeMethod
 	public void setUp(){
-		factory = new LarqSparqlQueryFactory();
+		factory = new JenaTextSparqlQueryFactory();
 	}
 	
 	

--- a/src/test/java/com/google/refine/test/rdf/vocab/AddPrefixCommandTest.java
+++ b/src/test/java/com/google/refine/test/rdf/vocab/AddPrefixCommandTest.java
@@ -24,7 +24,7 @@ import org.deri.grefine.rdf.vocab.imp.VocabularySearcher;
 import static org.testng.Assert.*;
 
 public class AddPrefixCommandTest{
-	private static final String TEMP_TEST_DIRECTORY = "tmp_VocabularySearchRelatedCommandsTest";
+	private static final String TEMP_TEST_DIRECTORY = "target/tmp_VocabularySearchRelatedCommandsTest";
 	ApplicationContext ctxt;
 	VocabularySearcher searcher;
 	VocabularyImporter importer;

--- a/src/test/java/com/google/refine/test/rdf/vocab/ImportPrefixTest.java
+++ b/src/test/java/com/google/refine/test/rdf/vocab/ImportPrefixTest.java
@@ -24,7 +24,7 @@ public class ImportPrefixTest {
 	@Test
 	public void testImportAndSeach()throws Exception{
 		VocabularyImporter fakeImporter = new FakeImporter();
-		VocabularySearcher searcher = new VocabularySearcher(new File("tmp"));
+		VocabularySearcher searcher = new VocabularySearcher(new File("target/tmp"));
 		searcher.importAndIndexVocabulary("foaf", "http://xmlns.com/foaf/0.1/", "http://xmlns.com/foaf/0.1/","1", fakeImporter);
 		
 		assertFalse(searcher.searchClasses("foaf:P", "1").isEmpty());

--- a/src/test/java/com/google/refine/tests/rdf/RdfSchemaSerializationTest.java
+++ b/src/test/java/com/google/refine/tests/rdf/RdfSchemaSerializationTest.java
@@ -1,21 +1,21 @@
 package com.google.refine.tests.rdf;
 
+import static org.testng.Assert.assertEquals;
+
 import java.io.StringWriter;
 import java.util.Properties;
 
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonNode;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.map.ObjectMapper;
+import org.deri.grefine.rdf.RdfSchema;
 import org.json.JSONObject;
 import org.json.JSONWriter;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.refine.util.ParsingUtilities;
-import org.deri.grefine.rdf.RdfSchema;
-
-import static org.testng.Assert.*;
 
 public class RdfSchemaSerializationTest {
 
@@ -42,11 +42,11 @@ public class RdfSchemaSerializationTest {
 	
 	void testJsonEquivalence(String actual, String expected)throws Exception{
 		ObjectMapper mapper = new ObjectMapper();
-		JsonFactory factory = mapper.getJsonFactory();
-		JsonParser jp = factory.createJsonParser(actual);
+		JsonFactory factory = mapper.getFactory();
+		JsonParser jp = factory.createParser(actual);
 		JsonNode actualObj = mapper.readTree(jp);
 		
-		jp = factory.createJsonParser(expected);
+		jp = factory.createParser(expected);
 		JsonNode  expectedObj = mapper.readTree(jp);
 		assertEquals(actualObj, expectedObj);
 	}

--- a/src/test/java/com/google/refine/tests/rdf/exporters/RdfExporterFacultyDataTest.java
+++ b/src/test/java/com/google/refine/tests/rdf/exporters/RdfExporterFacultyDataTest.java
@@ -50,8 +50,8 @@ public class RdfExporterFacultyDataTest {
 		exporter = new RdfExporter(ctxt,RDFFormat.RDFXML);
 		ControlFunctionRegistry.registerFunction("urlify", new Urlify());
 		ExpressionUtils.registerBinder(new RdfBinder(ctxt));
-			    
-		model = exporter.buildModel(project, engine, schema);
+	    
+		model = exporter.exportModel(project, engine, schema, null);
 		
 		assertEquals(project.rows.size(),3);
 		assertEquals(project.columnModel.getColumnIndexByName("Advisor"),5);

--- a/src/test/java/com/google/refine/tests/rdf/exporters/RdfExporterMultiRootNodesTest.java
+++ b/src/test/java/com/google/refine/tests/rdf/exporters/RdfExporterMultiRootNodesTest.java
@@ -48,8 +48,9 @@ public class RdfExporterMultiRootNodesTest {
 		exporter = new RdfExporter(ctxt,RDFFormat.RDFXML);
 		ControlFunctionRegistry.registerFunction("urlify", new Urlify());
 		ExpressionUtils.registerBinder(new RdfBinder(ctxt));
-			    
-		model = exporter.buildModel(project, engine, schema);
+	    
+//		model = exporter.buildModel(project, engine, schema);
+		model = exporter.exportModel(project, engine, schema, null);
 		
 		assertEquals(project.rows.size(),3);
 		assertEquals(project.columnModel.getColumnIndexByName("Advisor"),5);

--- a/src/test/java/com/google/refine/tests/rdf/exporters/RdfExporterPaymentDataTest.java
+++ b/src/test/java/com/google/refine/tests/rdf/exporters/RdfExporterPaymentDataTest.java
@@ -4,8 +4,16 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.Properties;
 
+import org.deri.grefine.rdf.RdfSchema;
+import org.deri.grefine.rdf.app.ApplicationContext;
+import org.deri.grefine.rdf.exporters.RdfExporter;
+import org.deri.grefine.rdf.expr.RdfBinder;
+import org.deri.grefine.rdf.expr.functions.strings.Urlify;
+import org.json.JSONObject;
+import org.mockito.Mockito;
 import org.openrdf.repository.Repository;
 import org.openrdf.repository.RepositoryConnection;
 import org.openrdf.repository.RepositoryException;
@@ -20,13 +28,9 @@ import com.google.refine.ProjectMetadata;
 import com.google.refine.browsing.Engine;
 import com.google.refine.expr.ExpressionUtils;
 import com.google.refine.grel.ControlFunctionRegistry;
-import com.google.refine.importers.TsvCsvImporter;
+import com.google.refine.importers.SeparatorBasedImporter;
+import com.google.refine.importing.ImportingManager;
 import com.google.refine.model.Project;
-import org.deri.grefine.rdf.RdfSchema;
-import org.deri.grefine.rdf.app.ApplicationContext;
-import org.deri.grefine.rdf.exporters.RdfExporter;
-import org.deri.grefine.rdf.expr.RdfBinder;
-import org.deri.grefine.rdf.expr.functions.strings.Urlify;
 import com.google.refine.util.ParsingUtilities;
 
 public class RdfExporterPaymentDataTest {
@@ -52,7 +56,16 @@ public class RdfExporterPaymentDataTest {
 		
 		Properties options = new Properties();
 //		options.put("ignore", "1");
-		new TsvCsvImporter().read(in, project,meta, options);
+		//new TsvCsvImporter().read(in, project,meta, options);
+		new SeparatorBasedImporter().parseOneFile(
+		        project,
+		        meta,
+		        ImportingManager.createJob(),
+		        "file-source",
+		        in,
+		        -1,
+		        Mockito.mock(JSONObject.class),
+		        new ArrayList<Exception>());
 		project.update();
 		//Guard assertion
 		assertEquals(project.rows.size(),2);
@@ -70,7 +83,8 @@ public class RdfExporterPaymentDataTest {
 		//export the project
 		engine = new Engine(project);
 		exporter = new RdfExporter(ctxt,RDFFormat.RDFXML);
-		model = exporter.buildModel(project, engine, schema);
+		//model = exporter.buildModel(project, engine, schema);
+		model = exporter.exportModel(project, engine, schema, null);
 	}
 	
 	@Test(groups={"rdf-schema-test"})

--- a/src/test/java/com/google/refine/tests/rdf/exporters/RdfExporterTest.java
+++ b/src/test/java/com/google/refine/tests/rdf/exporters/RdfExporterTest.java
@@ -59,7 +59,8 @@ public class RdfExporterTest {
 		ExpressionUtils.registerBinder(new RdfBinder(ctxt));
 	
 		
-		model = exporter.buildModel(project, engine,schema);
+		//model = exporter.buildModel(project, engine,schema);
+		model = exporter.exportModel(project, engine, schema, null);
 		
 		assertEquals(project.rows.size(),2);
 		assertEquals(project.columnModel.getColumnIndexByName("Job Title"),3);


### PR DESCRIPTION
Unit test now compile when running `mvn test-compile`. The tests themselves are still failing, but you can still run the build by providing `-Dmaven.test.skip=true`.

There were a number of test classes that referred to non-existent/no longer existing classes. From a quick preliminary peek, it seemed like the Larq* test classes could be referring to the JenaText* classes. I've refactored the Larq* classes to use the JenaText* classes to get the test classes to compile, but this might have been an incorrect step. Needs further investigation.